### PR TITLE
handle csrfOpts like other options

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const InvalidCSRFTokenError = createError('FST_CSRF_INVALID_TOKEN', 'Invalid csr
 const defaultOptions = {
   cookieKey: '_csrf',
   cookieOpts: { path: '/', sameSite: true, httpOnly: true },
+  csrfOpts: {},
   sessionKey: '_csrf',
   getToken: getTokenDefault,
   getUserInfo: getUserInfoDefault,
@@ -21,15 +22,15 @@ async function csrfPlugin (fastify, opts) {
   const {
     cookieKey,
     cookieOpts,
+    csrfOpts,
     sessionKey,
     getToken,
     getUserInfo,
     sessionPlugin
   } = Object.assign({}, defaultOptions, opts)
 
-  const csrfOpts = opts && opts.csrfOpts ? opts.csrfOpts : {}
-
   assert(typeof cookieKey === 'string', 'cookieKey should be a string')
+  assert(typeof csrfOpts === 'object', 'csrfOpts should be a object')
   assert(typeof sessionKey === 'string', 'sessionKey should be a string')
   assert(typeof getToken === 'function', 'getToken should be a function')
   assert(typeof getUserInfo === 'function', 'getUserInfo should be a function')


### PR DESCRIPTION
making the csrfOpts like the other opt
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
