### PR TITLE
Updated example getToken function in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,16 @@ function getToken (req) {
 It is recommended to provide a custom `getToken` function for performance and [security](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#use-of-custom-request-headers) reasons.
 
 ```js
-fastify.register(require('@fastify/csrf-protection'), { getToken: function (req) { req.headers['csrf'] } })
+fastify.register(require('@fastify/csrf-protection'), 
+  { getToken: function (req) { return req.headers['csrf-token'] } }
+)
+```
+or
+
+```js
+fastify.register(require('@fastify/csrf-protection'), 
+  { getToken: (req) => req.headers['csrf-token'] }
+)
 ```
 
 ## License


### PR DESCRIPTION
Minor speed bump in the example getToken method shown in the README. 

I believe there needs to be a return statement for the current example? I've also shown another using an arrow function, as well as changed the name of the example header to match one from the example list shown before. 

Hope this helps.