### PR TITLE
feat: enforce hmac key

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ You can also pass the [cookie serialization](https://github.com/fastify/fastify-
 The option `userInfo` is required if `getUserInfo` has been specified in the module option.
 The provided `userInfo` is hashed  inside the csrf token and it is not directly exposed.
 This option is needed to protect against cookie tossing.
+The option `csrfOpts.hmacKey` is required if `getUserInfo` has been specified in the module option, or when using [@fastify/cookie](https://github.com/fastify/fastify-cookie).
 
 ### `fastify.csrfProtection(request, reply, next)`
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ async function fastifyCsrfProtection (fastify, opts) {
 
   if (opts.getUserInfo) {
     csrfOpts.userInfo = true
+    assert(csrfOpts.hmacKey, 'csrfOpts.hmacKey is required and must be a valid hmac key')
   }
   const tokens = new CSRF(csrfOpts)
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function fastifyCsrfProtection (fastify, opts) {
 
   if (opts.getUserInfo) {
     csrfOpts.userInfo = true
-    assert(csrfOpts.hmacKey, 'csrfOpts.hmacKey is required and must be a valid hmac key')
+    checkHmacKey(csrfOpts.hmacKey)
   }
   const tokens = new CSRF(csrfOpts)
 
@@ -52,6 +52,7 @@ async function fastifyCsrfProtection (fastify, opts) {
   } else if (sessionPlugin === '@fastify/session') {
     fastify.decorateReply('generateCsrf', generateCsrfSession)
   } else {
+    checkHmacKey(csrfOpts.hmacKey)
     fastify.decorateReply('generateCsrf', generateCsrfCookie)
   }
 
@@ -130,6 +131,10 @@ function getTokenDefault (req) {
 
 function getUserInfoDefault (req) {
   return undefined
+}
+
+function checkHmacKey (hmacKey) {
+  assert(hmacKey, 'csrfOpts.hmacKey is required')
 }
 
 module.exports = fp(fastifyCsrfProtection, {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -17,7 +17,11 @@ test('Cookies', t => {
   async function load () {
     const fastify = Fastify()
     await fastify.register(fastifyCookie)
-    await fastify.register(fastifyCsrf)
+    await fastify.register(fastifyCsrf, {
+      csrfOpts: {
+        hmacKey: 'foo'
+      }
+    })
     fastify.decorate('testType', 'fastify-cookie')
     return fastify
   }
@@ -52,7 +56,12 @@ test('Cookies signed', t => {
   async function load () {
     const fastify = Fastify()
     await fastify.register(fastifyCookie, { secret: 'supersecret' })
-    await fastify.register(fastifyCsrf, { cookieOpts: { signed: true } })
+    await fastify.register(fastifyCsrf, {
+      cookieOpts: { signed: true },
+      csrfOpts: {
+        hmacKey: 'foo'
+      }
+    })
     fastify.decorate('testType', 'fastify-cookie')
     return fastify
   }
@@ -153,6 +162,16 @@ test('Validation', t => {
     })
   })
 
+  t.test('hmacKey', t => {
+    t.plan(1)
+    const fastify = Fastify()
+    fastify.register(fastifyCookie)
+    fastify.register(fastifyCsrf)
+    fastify.ready(err => {
+      t.equal(err.message, 'csrfOpts.hmacKey is required')
+    })
+  })
+
   t.end()
 })
 
@@ -165,7 +184,7 @@ test('csrf options', async () => {
     }
   })
 
-  const csrfOpts = { some: 'options' }
+  const csrfOpts = { some: 'options', hmacKey: 'foo' }
 
   await Fastify()
     .register(fastifyCookie)

--- a/test/user-info.test.js
+++ b/test/user-info.test.js
@@ -17,6 +17,9 @@ test('Cookies with User-Info', async t => {
   await fastify.register(fastifyCsrf, {
     getUserInfo (req) {
       return userInfoDB[req.body.username]
+    },
+    csrfOpts: {
+      hmacKey: 'foo'
     }
   })
 
@@ -73,6 +76,9 @@ test('Session with User-Info', async t => {
     sessionPlugin: '@fastify/session',
     getUserInfo (req) {
       return req.session.username
+    },
+    csrfOpts: {
+      hmacKey: 'foo'
     }
   })
 
@@ -122,6 +128,9 @@ test('SecureSession with User-Info', async t => {
     sessionPlugin: '@fastify/secure-session',
     getUserInfo (req) {
       return req.session.get('username')
+    },
+    csrfOpts: {
+      hmacKey: 'foo'
     }
   })
 
@@ -162,4 +171,22 @@ test('SecureSession with User-Info', async t => {
   })
 
   t.equal(response2.statusCode, 200)
+})
+
+test('Validate presence of hmac key with User-Info', async (t) => {
+  const fastify = Fastify()
+  await fastify.register(fastifySecureSession, {
+    key,
+    cookie: { path: '/', secure: false }
+  })
+
+  t.rejects(fastify.register(fastifyCsrf, {
+    getUserInfo (req) {
+      return req.session.get('username')
+    },
+    csrfOpts: {
+      hmacKey: undefined
+    }
+  })
+  )
 })


### PR DESCRIPTION
enforce usage of `hmac` key
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
