### PR TITLE
docs - update @fastify/session docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you use `@fastify/csrf-protection` with `@fastify/session`, the CSRF secret w
 By default, the key used will be named `_csrf`, but you can rename it via the `sessionKey` option.
 
 ```js
-fastify.register(require('@fastify-session'))
+fastify.register(require('@fastify-session'), { secret: "a string which is longer than 32 characters" })
 fastify.register(require('@fastify/csrf-protection'), { sessionPlugin: '@fastify/session' })
 
 // generate a token
@@ -99,7 +99,7 @@ If you use `@fastify/csrf-protection` with `@fastify/secure-session`, the CSRF s
 By default, the key used will be named `_csrf`, but you can rename it via the `sessionKey` option.
 
 ```js
-fastify.register(require('@fastify/secure-session'))
+fastify.register(require('@fastify/secure-session'), { secret: "a string which is longer than 32 characters" })
 fastify.register(require('@fastify/csrf-protection'), { sessionPlugin: '@fastify/secure-session' })
 
 // generate a token


### PR DESCRIPTION
As mentioned in https://github.com/fastify/session/issues/193, "secret" is now required by @fastify/session

#### Checklist

- [ x  ] run `npm run test` and `npm run benchmark`
- [  x ] tests and/or benchmarks are included
- [  x ] documentation is changed or added
- [ x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
