### PR TITLE
fix(types): use void as csrfProtection's return type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@ import { CookieSerializeOptions as FastifyCookieSerializeOptions } from "@fastif
 
 declare module 'fastify' {
   interface FastifyInstance {
-    csrfProtection(req: FastifyRequest, reply: FastifyReply, done: () => void): any;
+    csrfProtection(req: FastifyRequest, reply: FastifyReply, done: () => void): void;
   }
 
   interface FastifyReply {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -34,6 +34,8 @@ async function run() {
       return req.body
     }
   })
+  
+  fastify.addHook('onRequest', fastify.csrfProtection)
 }
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Using `any` as the return type for `csrfProtection` made it incompatible with `addHook`, because `csrfProtection` was interpreted as an async hook with 3 params, which is not allowed.

Instead `void` seems like the appropriate return type because the function is only invoked for its side-effects.
