### PR TITLE
docs(readme), test: generateCsrf no longer require await

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fastify.route({
   method: 'GET',
   path: '/',
   handler: async (req, reply) => {
-    const token = await reply.generateCsrf()
+    const token = reply.generateCsrf()
     return { token }
   }
 })
@@ -77,7 +77,7 @@ fastify.route({
   method: 'GET',
   path: '/',
   handler: async (req, reply) => {
-    const token = await reply.generateCsrf()
+    const token = reply.generateCsrf()
     return { token }
   }
 })
@@ -107,7 +107,7 @@ fastify.route({
   method: 'GET',
   path: '/',
   handler: async (req, reply) => {
-    const token = await reply.generateCsrf()
+    const token = reply.generateCsrf()
     return { token }
   }
 })
@@ -153,7 +153,7 @@ Apart from these safeguards, it is extremely important to [use HTTPS for your we
 Generates a secret (if it is not already present) and returns a promise that resolves to the associated secret.
 
 ```js
-const token = await reply.generateCsrf()
+const token = reply.generateCsrf()
 ```
 
 You can also pass the [cookie serialization](https://github.com/fastify/fastify-cookie) options to the function.

--- a/examples/example.mjs
+++ b/examples/example.mjs
@@ -24,7 +24,7 @@ fastify.route({
   method: 'GET',
   url: '/',
   handler: async (req, reply) => {
-    const token = await reply.generateCsrf()
+    const token = reply.generateCsrf()
     reply.type('text/html')
 
     return `

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -32,7 +32,7 @@ test('Cookies', t => {
     const fastify = await load()
 
     fastify.get('/', async (req, reply) => {
-      const token = await reply.generateCsrf()
+      const token = reply.generateCsrf()
       return { token }
     })
 
@@ -179,7 +179,7 @@ function runTest (t, load, tkn, hook = 'onRequest') {
     const fastify = await load()
 
     fastify.get('/', async (req, reply) => {
-      const token = await reply.generateCsrf()
+      const token = reply.generateCsrf()
       return { token }
     })
 
@@ -274,7 +274,7 @@ function runCookieOpts (t, load) {
     const fastify = await load()
 
     fastify.get('/', async (req, reply) => {
-      const token = await reply.generateCsrf({ path: '/hello' })
+      const token = reply.generateCsrf({ path: '/hello' })
       return { token }
     })
 

--- a/test/user-info.test.js
+++ b/test/user-info.test.js
@@ -28,7 +28,7 @@ test('Cookies with User-Info', async t => {
   }
 
   fastify.post('/login', async (req, reply) => {
-    const token = await reply.generateCsrf({ userInfo: userInfoDB[req.body.username] })
+    const token = reply.generateCsrf({ userInfo: userInfoDB[req.body.username] })
     return { token }
   })
 
@@ -84,7 +84,7 @@ test('Session with User-Info', async t => {
 
   fastify.post('/login', async (req, reply) => {
     req.session.username = req.body.username
-    const token = await reply.generateCsrf({ userInfo: req.body.username })
+    const token = reply.generateCsrf({ userInfo: req.body.username })
     return { token }
   })
 
@@ -136,7 +136,7 @@ test('SecureSession with User-Info', async t => {
 
   fastify.post('/login', async (req, reply) => {
     req.session.set('username', req.body.username)
-    const token = await reply.generateCsrf({ userInfo: req.body.username })
+    const token = reply.generateCsrf({ userInfo: req.body.username })
     return { token }
   })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

The `generateCsrf` functions have been modified to execute synchronously in #100. However, the README, examples, and tests still include unnecessary `await`. This pull request removes those `await` statements.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
  - `npm run benchmark` does not exist
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
