### PR TITLE
feat: respect logLevel when registering plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Apart from these safeguards, it is extremely important to [use HTTPS for your we
 | `getUserInfo` |  A sync function to get a string of user-specific information to prevent cookie tossing.     |
 | `sessionPlugin` |  The session plugin that you are using (if applicable).     |
 | `csrfOpts` |  The csrf options. See [@fastify/csrf](https://github.com/fastify/csrf).     |
+| `logLevel` | The log level for `fastify.csrfProtection` errors.     |
 
 ### `reply.generateCsrf([opts])`
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ async function fastifyCsrfProtection (fastify, opts) {
   assert(typeof getToken === 'function', 'getToken should be a function')
   assert(typeof getUserInfo === 'function', 'getUserInfo should be a function')
   assert(typeof cookieOpts === 'object', 'cookieOpts should be a object')
+  assert(typeof logLevel === 'string', 'logLevel should be a string')
   assert(
     ['@fastify/cookie', '@fastify/session', '@fastify/secure-session'].includes(sessionPlugin),
     "sessionPlugin should be one of the following: '@fastify/cookie', '@fastify/session', '@fastify/secure-session'"

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ const defaultOptions = {
   sessionKey: '_csrf',
   getToken: getTokenDefault,
   getUserInfo: getUserInfoDefault,
-  sessionPlugin: '@fastify/cookie'
+  sessionPlugin: '@fastify/cookie',
+  logLevel: 'warn'
 }
 
 async function fastifyCsrfProtection (fastify, opts) {
@@ -24,7 +25,8 @@ async function fastifyCsrfProtection (fastify, opts) {
     sessionKey,
     getToken,
     getUserInfo,
-    sessionPlugin
+    sessionPlugin,
+    logLevel
   } = Object.assign({}, defaultOptions, opts)
 
   const csrfOpts = opts?.csrfOpts ? opts.csrfOpts : {}
@@ -113,11 +115,11 @@ async function fastifyCsrfProtection (fastify, opts) {
   function csrfProtection (req, reply, next) {
     const secret = getSecret(req, reply)
     if (!secret) {
-      req.log.warn('Missing csrf secret')
+      req.log[logLevel]('Missing csrf secret')
       return reply.send(new MissingCSRFSecretError())
     }
     if (!tokens.verify(secret, getToken(req), getUserInfo(req))) {
-      req.log.warn('Invalid csrf token')
+      req.log[logLevel]('Invalid csrf token')
       return reply.send(new InvalidCSRFTokenError())
     }
     next()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -157,6 +157,18 @@ test('Validation', async t => {
       t.assert.strictEqual(err.message, "sessionPlugin should be one of the following: '@fastify/cookie', '@fastify/session', '@fastify/secure-session'")
     }
   })
+
+  await t.test('logLevel', async t => {
+    t.plan(1)
+    try {
+      const fastify = Fastify()
+      await fastify.register(fastifyCookie)
+      await fastify.register(fastifyCsrf, { logLevel: undefined })
+      await fastify.ready()
+    } catch (err) {
+      t.assert.strictEqual(err.message, 'logLevel should be a string')
+    }
+  })
 })
 
 test('csrf options', async () => {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -69,5 +69,6 @@ fastify.register(FastifyCsrfProtection, { csrfOpts: { }, sessionPlugin: '@fastif
 fastify.register(FastifyCsrfProtection, { csrfOpts: { }, sessionPlugin: '@fastify/secure-session' })
 fastify.register(FastifyCsrfProtection, { sessionPlugin: '@fastify/session' })
 fastify.register(FastifyCsrfProtection, { sessionPlugin: '@fastify/secure-session' })
+fastify.register(FastifyCsrfProtection, { logLevel: 'info' })
 
 expectDeprecated({} as FastifyCsrfOptions)


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and ~`npm run benchmark`~
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

We found ourselves wanting a little more control over the logs for our use-case, so it seemed to make sense to make use of `register`'s `logLevel` option for that.

I didn't update the docs because I think the assumption is that all plugins should use `logLevel` if it is set. If that's not the case I'd be happy to update them. 