### PR TITLE
chore: removed types deprecated

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,7 +20,8 @@ declare module 'fastify' {
   }
 }
 
-type FastifyCsrfProtection = FastifyPluginAsync<fastifyCsrfProtection.FastifyCsrfOptions>
+type FastifyCsrfProtection =
+  FastifyPluginAsync<fastifyCsrfProtection.FastifyCsrfProtectionOptions>
 
 declare namespace fastifyCsrfProtection {
   export type CookieSerializeOptions = FastifyCookieSerializeOptions
@@ -64,11 +65,6 @@ declare namespace fastifyCsrfProtection {
     FastifyCsrfProtectionOptionsFastifySession |
     FastifyCsrfProtectionOptionsFastifySecureSession
   )
-
-  /**
-   * @deprecated Use FastifyCsrfProtectionOptions instead
-   */
-  export type FastifyCsrfOptions = FastifyCsrfProtectionOptions
 
   export const fastifyCsrfProtection: FastifyCsrfProtection
   export { fastifyCsrfProtection as default }


### PR DESCRIPTION
Proposals:

- Rename `FastifyCsrfOptions` → `FastifyCsrfProtectionOptions` in the plugin type ( see screenshot )
- Remove `@deprecated` alias `FastifyCsrfOptions` that was kept for back-compat

<img width="1159" height="264" alt="screenshot" src="https://github.com/user-attachments/assets/458b7553-a5f5-404e-a87e-3b52f09a18ea" />

Note:

- Release a major version of the plugin after this pull request has been merged
- PR reference: 
      -  https://github.com/fastify/fastify-swagger-ui/pull/274