### PR TITLE
docs(readme): replace redirected url with new url

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The `secret` shown in the code above is strictly just an example. In all cases, 
 - Stored in some external services like KMS, Vault, or something similar
 - Read at run-time and supplied to this option
 - Of significant character length to provide adequate entropy
-- A truly random sequence of characters (You could use [crypto-random-string](https://npm.im/crypto-random-string))
+- A truly random sequence of characters (You could use [crypto-random-string](https://www.npmjs.com/package/crypto-random-string))
 
 Apart from these safeguards, it is extremely important to [use HTTPS for your website/app](https://letsencrypt.org/) to avoid a bunch of other potential security issues like [MITM attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) etc.
 


### PR DESCRIPTION
One less HTTP request to make as previous link was 301'd.

Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
