### PR TITLE
fix(types): allow omitting sessionPlugin for @fastify/cookie

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,18 +36,16 @@ declare namespace fastifyCsrfProtection {
     getToken?: GetTokenFn;
   }
 
+  type RequiredCSRFHmac = Omit<CSRFOptions, 'hmacKey' | 'userInfo'> &
+    Required<Pick<CSRFOptions, 'hmacKey'>> & { userInfo: true }
+
+  type OptionalCSRFNoUserInfo = Omit<CSRFOptions, 'userInfo'> & {
+    userInfo?: false;
+  }
+
   interface FastifyCsrfProtectionOptionsFastifyCookie {
     sessionPlugin?: '@fastify/cookie';
-    csrfOpts?: | ({
-      [k in keyof CSRFOptions]: k extends 'userInfo'
-        ? true
-        : CSRFOptions[k];
-    } & Required<Pick<CSRFOptions, 'hmacKey'>>)
-  | ({
-    [k in keyof CSRFOptions]: k extends 'userInfo'
-      ? false
-      : CSRFOptions[k];
-  });
+    csrfOpts?: OptionalCSRFNoUserInfo | RequiredCSRFHmac;
   }
 
   interface FastifyCsrfProtectionOptionsFastifySession {


### PR DESCRIPTION
Proposal:

- Fixes #133
- Fixes #135

#### Problem

When using `@fastify/cookie` (the default session plugin), TypeScript would error if `sessionPlugin` was omitted:

```ts
// This failed with:
// Property 'sessionPlugin' is missing in type '...' but required
// in type 'FastifyCsrfProtectionOptionsFastifySecureSession'
fastify.register(fastifyCsrfProtection, { cookieOpts: { signed: true } })
```

The union type was not discriminating correctly: since `FastifyCsrfProtectionOptionsFastifySession` and `FastifyCsrfProtectionOptionsFastifySecureSession` both require `sessionPlugin` as a required literal, TypeScript would fall through to those branches instead of matching `FastifyCsrfProtectionOptionsFastifyCookie`, where `sessionPlugin` is optional.

#### Fix

Simplifies the `csrfOpts` type for `FastifyCsrfProtectionOptionsFastifyCookie` into two explicit type aliases:

- `RequiredCSRFHmac`: used when `userInfo: true`, which makes `hmacKey`
  required (mirrors the runtime `assert(csrfOpts.hmacKey, ...)` check in
  `index.js` when `getUserInfo` is set with `@fastify/cookie`)
- `OptionalCSRFNoUserInfo`: the default case, `userInfo` is `false` or
  omitted, `hmacKey` not required

This replaces the previous mapped-type union, which was harder to read and didn't correctly reject `userInfo: true` without `hmacKey`.

#### Testing

Ran `npm run test:typescript` (tstyche) locally — all 5 assertions in `index.tst.ts` pass, including the negative case that checks `{ csrfOpts: { userInfo: true }, sessionPlugin: '@fastify/cookie' }` is correctly rejected without `hmacKey`.