### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ function getToken (req) {
 }
 ```
 
-It is recommended to provide a custom `getToken` function for performance and [security](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#use-of-custom-request-headers) reasons.
+It is recommended to provide a custom `getToken` function for performance and [security](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-custom-request-headers-for-ajaxapi) reasons.
 
 ```js
 fastify.register(require('@fastify/csrf-protection'),


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71